### PR TITLE
Adding the .gitignore file with an exception for node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+node_modules


### PR DESCRIPTION
As we plan to start using webpack in the plugin project to build the js files
locally, we will install the npm repository. This change will prevent the node_modules
from getting into git repository, as those files are temporal and should not
be tracked.

This patch doesnt have follow ups, because I wanted to test the newly discussed
update process.