### PR TITLE
fix: fix reopening modal if address has needs_correction status

### DIFF
--- a/Services/EnderecoService.php
+++ b/Services/EnderecoService.php
@@ -78,7 +78,7 @@ class EnderecoService {
                 $countryRepository = Shopware()->Models()->getRepository(Country::class);
                 $countryCode = strtolower($countryRepository->find($addressArray['country'])->getIso());
 
-                $locale = Shopware()->Container()->get('Shop')->getLocale()->getLocale();
+                $locale = Shopware()->Container()->get('shop')->getLocale()->getLocale();
                 $languageCode = explode('_', $locale)[0];
             } catch(\Exception $e) {
                 $this->logger->addError($e->getMessage());

--- a/Subscriber/Frontend.php
+++ b/Subscriber/Frontend.php
@@ -109,7 +109,7 @@ class Frontend implements SubscriberInterface
             return;
         }
 
-        if (!$this->config['isPluginActive']) {
+        if (!$this->config['checkExisting']) {
             return;
         }
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <label lang="en">Endereco Address-Services for Shopware (Download)</label>
     <label lang="de">Endereco Adress-Services für Shopware (Download)</label>
 
-    <version>3.5.3</version>
+    <version>3.5.4</version>
 
     <link>https://www.endereco.de/shopware</link>
 
@@ -30,6 +30,23 @@
     </description>
 
     <logo>/custom/plugins/EnderecoShopware5Client/logo.png</logo>
+
+    <changelog version="3.5.4">
+        <changes lang="de">
+            <![CDATA[
+            <ul>
+                <li><a href="https://github.com/Endereco/endereco-shopware5-client/issues/15">Issue #15</a> Fix für "Bei der Bestandskundenprüfung wird eine Adresse als falsche markiert es gibt aber keine Adressvorschläge im Frontend / Endlosschleife".</li>
+            </ul>
+        ]]>
+        </changes>
+        <changes lang="en">
+            <![CDATA[
+            <ul>
+                <li><a href="https://github.com/Endereco/endereco-shopware5-client/issues/15">Issue #15</a> Fix for "Bei der Bestandskundenprüfung wird eine Adresse als falsche markiert es gibt aber keine Adressvorschläge im Frontend / Endlosschleife".</li>
+            </ul>
+        ]]>
+        </changes>
+    </changelog>
 
     <changelog version="3.5.3">
         <changes lang="de">


### PR DESCRIPTION
In diesem Patch lösen wir zwei Probleme.
Das Hauptproblem ist, dass trotz deaktivierten Funktion "Bestandskunden prüfen" im checkout trotzdem das Fenster mit Adress aufgemacht wird. Wenn man dabei die Adresse nicht ändert und einfach auf speichern klickt, dann geht das Fenster nochmal.

Dieses Verhalten wird dadurch unterbunden, dass wir im "checkAdressesOrOpenModals" callback prüfen, ob 
 Bestandskundenprüfung aktiv ist. Wenn sie nicht aktiv ist, dann wird auch nichts unternomen.

IN der gleichen Methode wird übrigens die Adressprüfung getriggert. Somit wurden manche Kunden trotz deaktivierten Bestandskundenprüfung geprüft. Dieses Verhalten ist mit diesem Patch und 3.5.4 release gefixt.

Geprüft in 5.3, 5.6 und 5.7 versionen.