### PR TITLE
hotfix: add whitelist for payment methods that allow existing custome…

### DIFF
--- a/Subscriber/Frontend.php
+++ b/Subscriber/Frontend.php
@@ -115,6 +115,19 @@ class Frontend implements SubscriberInterface
 
         $sUserData = $view->getAssign('sUserData');
 
+        // Payments whitelist. Payments not in the list will have no adresscheck.
+        $currentPaymentMethod = $sUserData['additional']['payment']['name'];
+        $whitelistetPaymentMethods = [
+            'prepayment',
+            'cash',
+            'invoice',
+            'debit',
+            'sepa'
+        ];
+        if (!in_array($currentPaymentMethod, $whitelistetPaymentMethods)) {
+            return;
+        }
+
         if (array_key_exists('user', $sUserData['additional'])) {
             // Fetch all user addresses.
             /**

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <label lang="en">Endereco Address-Services for Shopware (Download)</label>
     <label lang="de">Endereco Adress-Services für Shopware (Download)</label>
 
-    <version>3.5.4</version>
+    <version>3.5.5</version>
 
     <link>https://www.endereco.de/shopware</link>
 
@@ -30,6 +30,23 @@
     </description>
 
     <logo>/custom/plugins/EnderecoShopware5Client/logo.png</logo>
+
+    <changelog version="3.5.5">
+        <changes lang="de">
+            <![CDATA[
+            <ul>
+                <li><a href="https://github.com/Endereco/endereco-shopware5-client/issues/17">Issue #17</a> Fix für "PayPal Express Kunden werden automatisch mit Bestandskundenprüfung geprüft".</li>
+            </ul>
+        ]]>
+        </changes>
+        <changes lang="en">
+            <![CDATA[
+            <ul>
+                <li><a href="https://github.com/Endereco/endereco-shopware5-client/issues/17">Issue #17</a> Fix for "PayPal Express customers are automatically verified with existing customer verification".</li>
+            </ul>
+        ]]>
+        </changes>
+    </changelog>
 
     <changelog version="3.5.4">
         <changes lang="de">


### PR DESCRIPTION
Es ist aktuell möglich auf der confirm Seite im Checkout zu landen ohne eine Adresse eingeben zu müssen. z.B. vie PayPal Express Checkout. Der Logik nach gilt so ein Kunde als Bestandskunde (weil er kein Status der Adressprüfung hat) und würde durch Endereco geprüft.

Diese Anpassung stellt eine Whitelist zur Verfügung. Falls die aktuelle Zahlungsart nicht in der Liste ist, wird auch keine Bestandskundenprüfung gemacht. PayPal und Amazon Pay sind nicht in der Liste. Können aber später optional hinzugefügt werden.