### PR TITLE
S5P-13: falsche doaccountings umsetzung

### DIFF
--- a/Subscriber/Frontend.php
+++ b/Subscriber/Frontend.php
@@ -55,11 +55,12 @@ class Frontend implements SubscriberInterface
 		return [
 			'Theme_Inheritance_Template_Directories_Collected' => 'onCollectTemplateDir',
 
-            'Shopware\Models\Customer\Address::postPersist' => 'onPostPersist',
-            'Shopware\Models\Customer\Address::postUpdate' => 'onPostUpdate',
-
             'Enlight_Controller_Action_PostDispatchSecure_Frontend' => 'onPostDispatch',
             'Enlight_Controller_Action_PostDispatchSecure_Backend_Config' => 'onPostDispatchConfig',
+
+            'Enlight_Controller_Action_PostDispatchSecure_Frontend_Register' => 'sendDoAccountingRegister',
+            'Enlight_Controller_Action_PostDispatchSecure_Frontend_Address' => 'sendDoAccountingAddress',
+            'Enlight_Controller_Action_PostDispatchSecure_Frontend_Forms' => 'sendDoAccountingForms',
 
             'Enlight_Controller_Action_PostDispatchSecure_Frontend_Account' => 'checkExistingCustomerAddresses',
             'Enlight_Controller_Action_PostDispatchSecure_Frontend_Checkout' => 'checkAdressesOrOpenModals',
@@ -67,6 +68,26 @@ class Frontend implements SubscriberInterface
             'Shopware_Modules_Order_SaveOrder_FilterAttributes' => 'onAfterOrderSaveOrder',
 		];
 	}
+
+    public function sendDoAccountingForms($args) {
+        $this->_doAccounting();
+    }
+
+    public function sendDoAccountingRegister($args) {
+        $request = $args->getRequest();
+        $blackListActions = [
+            'ajax_validate_password',
+            'ajax_validate_email'
+        ];
+        if (in_array($request->getActionName(), $blackListActions)) {
+            return;
+        }
+        $this->_doAccounting();
+    }
+
+	public function sendDoAccountingAddress($args) {
+	    $this->_doAccounting();
+    }
 
 	public function onAfterOrderSaveOrder($args) {
         $sOrder = $args->get('subject');
@@ -237,18 +258,6 @@ class Frontend implements SubscriberInterface
             // Check addresses.
             $this->enderecoService->checkAddresses(array_keys($addressesToCheck));
         }
-    }
-
-	public function onPostPersist($args) {
-        $this->_doAccounting();
-    }
-
-    public function onPostUpdate($args) {
-        $this->_doAccounting();
-    }
-
-    public function onPreRemove($args) {
-        $this->_doAccounting();
     }
 
     public function onPostDispatchConfig(\Enlight_Event_EventArgs $args)

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <label lang="en">Endereco Address-Services for Shopware (Download)</label>
     <label lang="de">Endereco Adress-Services für Shopware (Download)</label>
 
-    <version>3.5.5</version>
+    <version>3.5.6</version>
 
     <link>https://www.endereco.de/shopware</link>
 
@@ -30,6 +30,23 @@
     </description>
 
     <logo>/custom/plugins/EnderecoShopware5Client/logo.png</logo>
+
+    <changelog version="3.5.6">
+        <changes lang="de">
+            <![CDATA[
+            <ul>
+                <li><a href="https://github.com/Endereco/endereco-shopware5-client/issues/19">Issue #19</a> Fix für "Falsche doAccounting Umsetzung".</li>
+            </ul>
+        ]]>
+        </changes>
+        <changes lang="en">
+            <![CDATA[
+            <ul>
+                <li><a href="https://github.com/Endereco/endereco-shopware5-client/issues/19">Issue #19</a> Fix for "Wrong doAccounting implementation".</li>
+            </ul>
+        ]]>
+        </changes>
+    </changelog>
 
     <changelog version="3.5.5">
         <changes lang="de">


### PR DESCRIPTION
In der aktuellen Version des PLugins senden wir das doAccounting erst wenn der Kundendatensatz gespeichert wird. Weil jedoch die Felder für Session ID beim Laden der Seite dynamisch erstellt und befüllt werden, wird im Falle eines serverseitigen Validationsfehler die Session ID verloren, obwohl die geprüfte Adresse samt allen Statuscodes in der Form bleibt. Beseitigt der Kunde seinen Eingabefehler und sendet er die Form erneut ab, so wird seine geprüfte Adresse gespeichert, wird würden in dem Fall jedoch kein doAccounting absenden, was falsch ist.

Mit dieser Anpassung senden wir das doAccounting sofort nach dem Absenden der Form. Falls der User ein Validationsfehler hat und diesen beseitigt ohne die Adresse anzufassen, wird er nicht doppelt abgerechnet.

Das entsprich somit dem Konzept des erfolgbasierten Abrechnen am meisten.