### PR TITLE
Remove logo element from plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,30 @@
         ]]>
     </description>
 
-    <logo>/custom/plugins/EnderecoShopware5Client/logo.png</logo>
+    <changelog version="3.11.1">
+        <changes lang="de">
+            <![CDATA[
+            <ul>
+                <li><b>Fehlerbehebungen</b>
+                    <ul>
+                        <li>Aus der Plugin-Definition wurde das Logo entfernt, da es keinen Einfluss auf die Darstellung des Plugins hat und in manchen Fällen zu Installationsproblemen führen konnte.</li>
+                    </ul>
+                </li>
+            </ul>
+        ]]>
+        </changes>
+        <changes lang="en">
+            <![CDATA[
+            <ul>
+                <li><b>Bug Fixes</b>
+                    <ul>
+                        <li>The logo was removed from the plugin definition, as it has no effect on the plugin’s appearance and could, in some cases, lead to installation issues.</li>
+                    </ul>
+                </li>
+            </ul>
+            ]]>
+        </changes>
+    </changelog>
 
     <changelog version="3.11.0">
         <changes lang="de">


### PR DESCRIPTION
Removed the <logo> element from plugin.xml to ensure compatibility with Shopware 5. Some installations failed because the Shopware schema does not expect a logo tag unless used via the Shopware Store. The logo was originally intended for display purposes but had no functional effect. This change prevents installation issues on customer systems.